### PR TITLE
Bug fix: do not test cessation date if .. in IsBetween

### DIFF
--- a/cmp/between.go
+++ b/cmp/between.go
@@ -2,6 +2,8 @@ package cmp
 
 import (
 	"fmt"
+
+	"github.com/sfomuseum/go-edtf"
 )
 
 // IsBetween reports whether the EDTF string `d` is betwen the EDTF strings `inceptions` and `cessation`.
@@ -17,14 +19,17 @@ func IsBetween(d string, inception string, cessation string) (bool, error) {
 		return false, nil
 	}
 
-	is_after_cessation, err := IsAfter(d, cessation)
+	if cessation != edtf.OPEN {
 
-	if err != nil {
-		return false, fmt.Errorf("Failed to determine if date is after cessation date, %w", err)
-	}
+		is_after_cessation, err := IsAfter(d, cessation)
 
-	if is_after_cessation {
-		return false, nil
+		if err != nil {
+			return false, fmt.Errorf("Failed to determine if date is after cessation date, %w", err)
+		}
+
+		if is_after_cessation {
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/cmp/between_test.go
+++ b/cmp/between_test.go
@@ -2,6 +2,8 @@ package cmp
 
 import (
 	"testing"
+
+	"github.com/sfomuseum/go-edtf"
 )
 
 func TestIsBetween(t *testing.T) {
@@ -10,6 +12,7 @@ func TestIsBetween(t *testing.T) {
 		[3]string{"2024-03-21", "2022-12", "2024-06-17"},
 		[3]string{"2024-03-21", "2024~", "2024-06-17"},
 		[3]string{"2024-03-21", "2024~", "2024~"},
+		[3]string{"2024-03-21", "2024~", edtf.OPEN},
 	}
 
 	tests_before := [][3]string{


### PR DESCRIPTION
* Bug fix: do not test cessation date if .. in `cmp.IsBetween`